### PR TITLE
Fix User Settings Registration

### DIFF
--- a/Sources/NotificationsProvider/GXUserNotificationsProviderOneSignal.swift
+++ b/Sources/NotificationsProvider/GXUserNotificationsProviderOneSignal.swift
@@ -49,7 +49,9 @@ open class GXUserNotificationsProviderOneSignal: NSObject, GXUserNotificationsPr
 	
 	open func registerForUserNotificationTypes(types: UInt) {
 		OneSignal.Notifications.requestPermission { granted in
-			GXUserNotificationsManager.onDidRegisterUserNotificationSettings()
+			if granted {
+				GXUserNotificationsManager.onDidRegisterUserNotificationSettings()
+			}
 		}
 	}
 	

--- a/Sources/NotificationsProvider/GXUserNotificationsProviderOneSignal.swift
+++ b/Sources/NotificationsProvider/GXUserNotificationsProviderOneSignal.swift
@@ -47,6 +47,12 @@ open class GXUserNotificationsProviderOneSignal: NSObject, GXUserNotificationsPr
 	
 	public final var remoteAppDelegate: any GXRemoteNotificationsProviderAppDelegateProtocol { self }
 	
+	open func registerForUserNotificationTypes(types: UInt) {
+		OneSignal.Notifications.requestPermission { granted in
+			GXUserNotificationsManager.onDidRegisterUserNotificationSettings()
+		}
+	}
+	
 	// MARK: Remote
 	
 	open func registerForPushNotifications() -> Void {


### PR DESCRIPTION
This PR fixes the issue that subscription status detail remained as "Prompted But Never Answered" until next app launch, even after the permission was granted by the user in the UI prompt.